### PR TITLE
Fix for dupes in the calibrationhistory table

### DIFF
--- a/peer_grading/calibration.py
+++ b/peer_grading/calibration.py
@@ -28,6 +28,13 @@ def create_and_save_calibration_record(calibration_data):
             student_id=calibration_data['student_id'],
             location=calibration_data['location'],
         )
+    except DatabaseError:
+        error_msg = "get_or_create failed with DatabaseError "
+        "student id {0} and location {1}.".format(calibration_data['student_id'],
+                                                  calibration_data['location'])
+        log.exception(error_msg)
+        return False, (error_msg)
+        
     except Exception:
         error_msg = "Cannot get or create CalibrationRecord with "
         "student id {0} and location {1}.".format(calibration_data['student_id'],
@@ -132,7 +139,15 @@ def get_calibration_essay(location, student_id):
         return False, "The course staff has not graded enough calibration essays yet, please check back later."
 
     #Get all student calibration done on current problem
-    student_calibration_history, success = CalibrationHistory.objects.get_or_create(student_id=student_id, location=location)
+    try:
+        student_calibration_history, success = CalibrationHistory.objects.get_or_create(student_id=student_id, location=location)
+    except DatabaseError:
+        error_msg = "get_or_create failed with DatabaseError "
+        "student id {0} and location {1}.".format(student_id,
+                                                  location)
+        log.exception(error_msg)
+        return False, (error_msg)
+        
     student_calibration_records = student_calibration_history.get_all_calibration_records()
     student_calibration_ids = [cr.submission.id for cr in list(student_calibration_records)]
     calibration_essay_ids = [cr.id for cr in list(calibration_submissions)]
@@ -169,7 +184,15 @@ def check_calibration_status(location,student_id):
         return False, "Invalid problem id specified: {0}".format(location)
 
     #Get student calibration history and count number of records associated with it
-    calibration_history, created = CalibrationHistory.objects.get_or_create(student_id=student_id, location=location)
+    try:
+        calibration_history, created = CalibrationHistory.objects.get_or_create(student_id=student_id, location=location)
+    except DatabaseError:
+        error_msg = "get_or_create failed with DatabaseError "
+        "student id {0} and location {1}.".format(student_id,
+                                                  location)
+        log.exception(error_msg)
+        return False, (error_msg)
+    
     max_score = matching_submissions[0].max_score
     calibration_record_count = calibration_history.get_calibration_record_count()
 

--- a/peer_grading/migrations/0007_auto__add_unique_calibrationhistory_student_id_location.py
+++ b/peer_grading/migrations/0007_auto__add_unique_calibrationhistory_student_id_location.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding unique constraint on 'CalibrationHistory', fields ['student_id', 'location']
+        db.create_unique('peer_grading_calibrationhistory', ['student_id', 'location'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'CalibrationHistory', fields ['student_id', 'location']
+        db.delete_unique('peer_grading_calibrationhistory', ['student_id', 'location'])
+
+
+    models = {
+        'controller.submission': {
+            'Meta': {'object_name': 'Submission'},
+            'answer': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'duplicate_submission_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'grader_settings': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'has_been_duplicate_checked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initial_display': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'is_duplicate': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_plagiarized': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'location': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'db_index': 'True'}),
+            'max_score': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'next_grader_type': ('django.db.models.fields.CharField', [], {'default': "'NA'", 'max_length': '2'}),
+            'posted_results_back_to_queue': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'preferred_grader_type': ('django.db.models.fields.CharField', [], {'default': "'NA'", 'max_length': '2'}),
+            'previous_grader_type': ('django.db.models.fields.CharField', [], {'default': "'NA'", 'max_length': '2'}),
+            'problem_id': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'prompt': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'rubric': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'skip_basic_checks': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'student_response': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'student_submission_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'xqueue_queue_name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128'}),
+            'xqueue_submission_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '1024'}),
+            'xqueue_submission_key': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '1024'})
+        },
+        'peer_grading.calibrationhistory': {
+            'Meta': {'unique_together': "(('student_id', 'location'),)", 'object_name': 'CalibrationHistory'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'db_index': 'True'}),
+            'problem_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '1024'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'})
+        },
+        'peer_grading.calibrationrecord': {
+            'Meta': {'object_name': 'CalibrationRecord'},
+            'actual_score': ('django.db.models.fields.IntegerField', [], {}),
+            'calibration_history': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['peer_grading.CalibrationHistory']"}),
+            'feedback': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_pre_calibration': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'rubric_scores': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            'rubric_scores_complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'score': ('django.db.models.fields.IntegerField', [], {}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['controller.Submission']"})
+        }
+    }
+
+    complete_apps = ['peer_grading']

--- a/peer_grading/models.py
+++ b/peer_grading/models.py
@@ -11,6 +11,9 @@ class CalibrationHistory(models.Model):
     #Currently use location instead of problem_id
     problem_id = models.CharField(max_length=CHARFIELD_LEN_LONG, default="")
     location = models.CharField(max_length=CHARFIELD_LEN_SMALL, default="", db_index = True)
+    
+    class Meta:
+        unique_together = ("student_id", "location")
 
     def __unicode__(self):
         history_row = ("Calibration history for student {0} on problem {1} at location {2}").format(

--- a/peer_grading/tests.py
+++ b/peer_grading/tests.py
@@ -7,6 +7,7 @@ import unittest
 from datetime import datetime
 import logging
 import urlparse
+from mock import Mock, patch
 
 from django.contrib.auth.models import User
 from django.test.client import Client
@@ -19,6 +20,7 @@ from django.utils import timezone
 import project_urls
 from controller.xqueue_interface import handle_submission
 import peer_grading_util
+from views import create_and_save_calibration_record
 
 log = logging.getLogger(__name__)
 
@@ -351,6 +353,21 @@ class IsCalibratedTest(unittest.TestCase):
 
         #Now records exist and error is 0, so student should be calibrated
         self.assertEqual(body['calibrated'], calibration_val)
+
+    @patch('peer_grading.models.CalibrationHistory.save', Mock(side_effect=Exception()))
+    def test_calibration_history_exception(self):
+
+        calibration_data = {
+                            'submission_id': 1234,
+                            'score': 56,
+                            'feedback': 'feedback',
+                            'student_id': '789',
+                            'location': '0123',
+                            }
+
+        success, data = create_and_save_calibration_record(calibration_data)
+        self.assertRaises(Exception)
+        
 
 class PeerGradingUtilTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
A new function to check for dupes in calibrationhistory table
and if found it deletes all but that with the lowest id for
that student_id, location.
Includes an updated unit test that exercises the new function.
