### PR TITLE
don't ignore the ml_models dir, just the files inside of it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ cover/
 nosetests.xml
 coverage.xml
 .coverage
-ml_models
 celerybeat-schedule.*
 django_cache/*
 !.vc

--- a/ml_models/.gitignore
+++ b/ml_models/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore


### PR DESCRIPTION
if the ml_models dir doesn't exist, then you get an error like this:

```
[2013-08-09 16:39:41,219: ERROR/MainProcess] Could not remove ml grading models!
Traceback (most recent call last):
  File "./controller/tasks.py", line 104, in expire_submissions_task
    expire_submissions.remove_old_model_files()
  File "./controller/expire_submissions.py", line 222, in remove_old_model_files
    onlyfiles = [ f for f in os.listdir(settings.ML_MODEL_PATH) if os.path.isfile(os.path.join(settings.ML_MODEL_PATH,f)) ]
OSError: [Errno 2] No such file or directory: 'ml_models/'
```

So we should just include this dir in the repo, so one doesn't have to remember to create it manually.
