### PR TITLE
Handling case where 'BC' is latest grader but 'PE' grades exist

### DIFF
--- a/controller/models.py
+++ b/controller/models.py
@@ -148,8 +148,8 @@ class Submission(models.Model):
             return_dict.update(last_grader.get_latest_rubric_headers_and_scores())
             return return_dict
         #If grader is ML or instructor, only send back last successful submission
-        elif all_graders[0].grader_type in ["IN", "ML"] or \
-             all_graders[0].grader_type == "BC" and "PE" not in all_graders_types:
+        elif (all_graders[0].grader_type in ["IN", "ML"] or 
+              all_graders[0].grader_type == "BC" and "PE" not in all_graders_types):
             return_dict =  {'score': all_graders[0].score, 'feedback': all_graders[0].feedback,
                     'grader_type' : all_graders[0].grader_type, 'success' : True,
                     'grader_id' : all_graders[0].id , 'submission_id' : self.id , 'student_id' : self.student_id}
@@ -157,8 +157,8 @@ class Submission(models.Model):
             return_dict.update(all_graders[0].get_latest_rubric_headers_and_scores())
             return return_dict
         #If grader is peer, send back all peer judgements
-        elif self.previous_grader_type == "PE" or \
-             all_graders[0].grader_type == "BC" and "PE" in all_graders_types:
+        elif (self.previous_grader_type == "PE" or 
+              all_graders[0].grader_type == "BC" and "PE" in all_graders_types):
             peer_graders = [p for p in all_graders if p.grader_type == "PE"]
             combined_rubrics = [p.check_for_and_return_latest_rubric() for p in peer_graders]
             rubric_headers = [p.get_latest_rubric_headers_and_scores().get("rubric_headers", []) for p in peer_graders]


### PR DESCRIPTION
This happens in cases where submissions are duplicated, and there are a bunch of these on Stanford's instance.
The old behavior would only post back the BC feedback to xqueue.
The new behavior should post back all PE feedback instead.
