### PR TITLE
config-prefix: Allow to specify SERVICE_VARIANT, used as config prefix

### DIFF
--- a/controller/util.py
+++ b/controller/util.py
@@ -340,7 +340,7 @@ def _success_response(data, version):
     return HttpResponse(json.dumps(response), mimetype="application/json")
 
 def update_users_from_file():
-    auth_path = settings.ENV_ROOT / "auth.json"
+    auth_path = settings.ENV_ROOT / settings.CONFIG_PREFIX + "auth.json"
     log.info(' [*] reading {0}'.format(auth_path))
 
     with open(auth_path) as auth_file:

--- a/edx_ora/aws.py
+++ b/edx_ora/aws.py
@@ -11,11 +11,14 @@ import logging
 ######################################################################
 #General config
 
-
-
 ######################################################################
+#Allow to specify a prefix for env/auth configuration files
+SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', '')
+if SERVICE_VARIANT:
+    CONFIG_PREFIX = SERVICE_VARIANT + "."
+
 #Read config from json file
-with open(ENV_ROOT / "env.json") as env_file:
+with open(ENV_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
 
 #Debug
@@ -68,7 +71,7 @@ LOGGING = get_logger_config(debug=DEBUG)
 
 ######################################################################
 # Read secure config
-with open(ENV_ROOT / "auth.json") as auth_file:
+with open(ENV_ROOT / CONFIG_PREFIX + "auth.json") as auth_file:
     AUTH_TOKENS = json.load(auth_file)
 
 XQUEUE_INTERFACE = AUTH_TOKENS['XQUEUE_INTERFACE']

--- a/edx_ora/settings.py
+++ b/edx_ora/settings.py
@@ -29,6 +29,7 @@ DEFAULT_ESTIMATED_GRADING_TIME = 3 * 24 * 60 * 60 # seconds, amount of time to d
 MIN_RANDOMIZED_PROCESS_SLEEP_TIME = 0 # Minimum time for a process to sleep, to avoid process collision
 MAX_RANDOMIZED_PROCESS_SLEEP_TIME = 10 * 60 # Maximum time for a process to sleep, to avoid process collision
 RECENT_NOTIFICATION_CHECK_INTERVAL = 1 * 24 * 60 * 60 #in seconds. Will not save a record for a student notification check if it happens at least this timeframe apart
+CONFIG_PREFIX = '' # To append at the beginning of the config file name
 
 #Config for specific graders
 #ML


### PR DESCRIPTION
This is necessary to be able to get several services using the `/opt/wwc/env.json` & `/opt/wwc/auth.json` files. The configuration files would get overwitten when this is used by several different services cohabiting on a single instance.

See https://github.com/edx/configuration/pull/234 for more details.
