### PR TITLE
Fix problem name display

### DIFF
--- a/controller/capsules.py
+++ b/controller/capsules.py
@@ -61,6 +61,15 @@ class LocationCapsule(object):
         """
         raise NotImplementedError()
 
+    def problem_name(self):
+        """
+        Get the problem name for this location.
+        """
+
+        # Get the last problem submitted and read its name.
+        # Do this to support course staff changing problem names.
+        return self.location_submissions().order_by("-date_modified")[0].problem_id
+
 class CourseCapsule(object):
     """
     Encapsulates information that graders may want about a course.

--- a/peer_grading/views.py
+++ b/peer_grading/views.py
@@ -358,7 +358,7 @@ def get_problem_list(request):
     for location in locations_for_course:
         pl = peer_grading_util.PeerLocation(location,student_id)
         if pl.submitted_count()>0:
-            problem_name = Submission.objects.filter(location=location)[0].problem_id
+            problem_name = pl.problem_name()
             submissions_pending = pl.pending_count()
             submissions_graded = pl.graded_count()
             submissions_required = max([0,pl.required_count() - submissions_graded])

--- a/staff_grading/tests.py
+++ b/staff_grading/tests.py
@@ -216,6 +216,26 @@ class StaffGradingViewTest(unittest.TestCase):
 
         self.assertEqual(rescore,test_sub.id)
 
+    def test_get_problem_name(self):
+        """
+        Test to see if the correct problem name is returned by a location capsule.
+        Saves two submissions, and tests to see if the problem name is updated.
+        """
+        problem_id_one = "Problem One"
+        problem_id_two = "Problem Two"
+
+        test_sub=test_util.get_sub("IN",STUDENT_ID,LOCATION)
+        test_sub.problem_id = problem_id_one
+        test_sub.save()
+
+        sl = StaffLocation(LOCATION)
+        self.assertEqual(sl.problem_name(), problem_id_one)
+
+        test_sub2=test_util.get_sub("IN",STUDENT_ID,LOCATION)
+        test_sub2.problem_id = problem_id_two
+        test_sub2.save()
+
+        self.assertEqual(sl.problem_name(), problem_id_two)
 
 
 

--- a/staff_grading/views.py
+++ b/staff_grading/views.py
@@ -277,7 +277,7 @@ def get_problem_list(request):
     location_info=[]
     for location in locations_for_course:
         sl = staff_grading_util.StaffLocation(location)
-        problem_name = Submission.objects.filter(location=location)[0].problem_id
+        problem_name = sl.problem_name()
         submissions_pending = sl.pending_count()
         finished_instructor_graded = sl.graded_count()
         min_scored_for_location=settings.MIN_TO_USE_PEER


### PR DESCRIPTION
Previously, instructors could not change the problem name displayed because ORA always pulled the name from the first submission when showing peer and staff grading lists.  Moved the logic into a common function and made it default to the latest available submission.
