### PR TITLE
change StaffLocation graded query due to overgrading

### DIFF
--- a/staff_grading/staff_grading_util.py
+++ b/staff_grading/staff_grading_util.py
@@ -20,7 +20,7 @@ class StaffLocation(LocationCapsule):
         """
         Finds all submissions that have been instructor graded, and are now complete.
         """
-        return self.location_submissions().filter(previous_grader_type="IN", state=SubmissionState.finished)
+        return self.location_submissions().filter(grader__grader_type="IN", state=SubmissionState.finished)
 
     def graded_count(self):
         """

--- a/staff_grading/tests.py
+++ b/staff_grading/tests.py
@@ -165,10 +165,19 @@ class StaffGradingViewTest(unittest.TestCase):
         test_sub=test_util.get_sub("IN",STUDENT_ID, LOCATION)
         test_sub.save()
 
-        test_sub2=test_util.get_sub("IN",STUDENT_ID, LOCATION)
+        test_sub2=test_util.get_sub("PE",STUDENT_ID, LOCATION)
         test_sub2.state = SubmissionState.finished
-        test_sub2.previous_grader_type = "IN"
+        test_sub2.previous_grader_type = "PE"
         test_sub2.save()
+
+        test_grader_in=test_util.get_grader("IN")
+        test_grader_in.submission=test_sub2
+        test_grader_in.save()
+
+        test_grader_pe=test_util.get_grader("PE")
+        test_grader_pe.submission=test_sub2
+        test_grader_pe.save()
+
 
         sl = StaffLocation(LOCATION)
         self.assertEqual(sl.location_submissions().count(),2)


### PR DESCRIPTION
@VikParuchuri 
a simple change to use a join with the controller_grader table to calculate instructor-graded submissions.

Necessary because overgrading can change the grader_types in controller_submission.
