### PR TITLE
Make minimum to use AI and minimum to use peer user-configurable

### DIFF
--- a/controller/capsules.py
+++ b/controller/capsules.py
@@ -68,7 +68,13 @@ class LocationCapsule(object):
 
         # Get the last problem submitted and read its name.
         # Do this to support course staff changing problem names.
-        return self.location_submissions().order_by("-date_modified")[0].problem_id
+        return self.latest_submission().problem_id
+
+    def latest_submission(self):
+        """
+        Get the latest submission for this location.
+        """
+        return self.location_submissions().order_by("-date_modified")[0]
 
 class CourseCapsule(object):
     """

--- a/controller/control_util.py
+++ b/controller/control_util.py
@@ -1,6 +1,5 @@
 import json
 from django.conf import settings
-import peer_grading.peer_grading_util
 
 class SubmissionControl():
     """
@@ -40,6 +39,14 @@ class SubmissionControl():
     def peer_grade_finished_submissions_when_none_pending(self):
         return self.cd.get('peer_grade_finished_submissions_when_none_pending',
                            settings.PEER_GRADE_FINISHED_SUBMISSIONS_WHEN_NONE_PENDING)
+
+    @property
+    def minimum_to_use_peer(self):
+        return self.cd.get('staff_minimum_for_peer_grading', settings.MIN_TO_USE_PEER)
+
+    @property
+    def minimum_to_use_ai(self):
+        return self.cd.get('staff_minimum_for_ai_grading', settings.MIN_TO_USE_ML)
 
     @classmethod
     def peer_grade_finished_subs(cls, peer_location):

--- a/controller/grader_interface.py
+++ b/controller/grader_interface.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.utils import timezone
 from statsd import statsd
+from control_util import SubmissionControl
 
 import json
 import logging
@@ -46,9 +47,11 @@ def get_submission_ml(request):
             continue
 
         sl = staff_grading_util.StaffLocation(location)
+        control = SubmissionControl(sl.latest_submission())
+
         subs_graded_by_instructor = sl.graded_count()
         success = ml_grading_util.check_for_all_model_and_rubric_success(location)
-        if subs_graded_by_instructor >= settings.MIN_TO_USE_ML and success:
+        if subs_graded_by_instructor >= control.minimum_to_use_ai and success:
             to_be_graded = Submission.objects.filter(
                 location=location,
                 state=SubmissionState.waiting_to_be_graded,

--- a/ml_grading/ml_model_creation.py
+++ b/ml_grading/ml_model_creation.py
@@ -19,6 +19,7 @@ from controller import util
 
 from controller.models import Submission
 from staff_grading import staff_grading_util
+from controller.control_util import SubmissionControl
 
 from ml_grading.models import CreatedModel
 import ml_grading.ml_grading_util as ml_grading_util
@@ -36,16 +37,18 @@ def handle_single_location(location):
         transaction.commit()
         gc.collect()
         sl = staff_grading_util.StaffLocation(location)
+        control = SubmissionControl(sl.latest_submission())
+
         subs_graded_by_instructor = sl.graded()
         log.info("Checking location {0} to see if essay count {1} greater than min {2}".format(
             location,
             subs_graded_by_instructor.count(),
-            settings.MIN_TO_USE_ML,
+            control.minimum_to_use_ai,
         ))
         graded_sub_count=subs_graded_by_instructor.count()
 
         #check to see if there are enough instructor graded essays for location
-        if graded_sub_count >= settings.MIN_TO_USE_ML:
+        if graded_sub_count >= control.minimum_to_use_ai:
 
             location_suffixes=ml_grading_util.generate_rubric_location_suffixes(subs_graded_by_instructor, grading=False)
 

--- a/peer_grading/tests.py
+++ b/peer_grading/tests.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 import project_urls
 from controller.xqueue_interface import handle_submission
 import peer_grading_util
+from controller.control_util import SubmissionControl
 
 log = logging.getLogger(__name__)
 
@@ -104,7 +105,10 @@ class LMSInterfacePeerGradingTest(unittest.TestCase):
         grader.grader_id = "2"
         grader.save()
 
-        for i in xrange(0,settings.MIN_TO_USE_PEER):
+        pl = peer_grading_util.PeerLocation(LOCATION, "1")
+        control = SubmissionControl(pl.latest_submission())
+
+        for i in xrange(0, control.minimum_to_use_peer):
             test_sub = test_util.get_sub("PE", "1", LOCATION, "PE")
             test_sub.save()
             grader = test_util.get_grader("IN")
@@ -365,7 +369,14 @@ class PeerGradingUtilTest(unittest.TestCase):
             }
 
     def test_get_single_peer_grading_item(self):
-        for i in xrange(0,settings.MIN_TO_USE_PEER):
+        test_sub = test_util.get_sub("PE", STUDENT_ID, LOCATION, "PE")
+        test_sub.save()
+        handle_submission(test_sub)
+
+        pl = peer_grading_util.PeerLocation(LOCATION, STUDENT_ID)
+        control = SubmissionControl(pl.latest_submission())
+
+        for i in xrange(0, control.minimum_to_use_peer):
             test_sub = test_util.get_sub("PE", STUDENT_ID, LOCATION, "PE")
             test_sub.save()
             handle_submission(test_sub)

--- a/staff_grading/views.py
+++ b/staff_grading/views.py
@@ -23,6 +23,7 @@ from controller import grader_util
 from controller import rubric_functions
 import staff_grading_util
 from ml_grading import ml_grading_util
+from controller.control_util import SubmissionControl
 
 from django.db import connection
 
@@ -107,6 +108,7 @@ def get_next_submission(request):
     ml_error_message="Machine learning error information: " + ml_error_message
 
     sl = staff_grading_util.StaffLocation(submission.location)
+    control = SubmissionControl(sl.latest_submission())
     if submission.state != SubmissionState.being_graded:
         log.error("Instructor grading got submission {0} in an invalid state {1} ".format(sid, submission.state))
         return util._error_response('wrong_internal_state',
@@ -119,11 +121,11 @@ def get_next_submission(request):
                 'rubric': submission.rubric,
                 'prompt': submission.prompt,
                 'max_score': submission.max_score,
-                'ml_error_info' : ml_error_message,
-                'problem_name' : submission.problem_id,
-                'num_graded' : sl.graded_count(),
-                'num_pending' : sl.pending_count(),
-                'min_for_ml' : settings.MIN_TO_USE_ML,
+                'ml_error_info': ml_error_message,
+                'problem_name': submission.problem_id,
+                'num_graded': sl.graded_count(),
+                'num_pending': sl.pending_count(),
+                'min_for_ml': control.minimum_to_use_ai,
                 }
 
     util.log_connection_data()
@@ -277,25 +279,22 @@ def get_problem_list(request):
     location_info=[]
     for location in locations_for_course:
         sl = staff_grading_util.StaffLocation(location)
+        control = SubmissionControl(sl.latest_submission())
         problem_name = sl.problem_name()
         submissions_pending = sl.pending_count()
         finished_instructor_graded = sl.graded_count()
-        min_scored_for_location=settings.MIN_TO_USE_PEER
-        location_ml_count = Submission.objects.filter(location=location, preferred_grader_type="ML").count()
-        if location_ml_count>0:
-            min_scored_for_location=settings.MIN_TO_USE_ML
 
-        submissions_required = max([0,min_scored_for_location-finished_instructor_graded])
+        submissions_required = max([0, sl.minimum_to_score() - finished_instructor_graded])
 
         problem_name_from_location=location.split("://")[1]
         location_dict={
-            'location' : location,
-            'problem_name' : problem_name,
-            'problem_name_from_location' : problem_name_from_location,
-            'num_graded' : finished_instructor_graded,
-            'num_pending' : submissions_pending,
-            'num_required' : submissions_required,
-            'min_for_ml' : settings.MIN_TO_USE_ML,
+            'location': location,
+            'problem_name': problem_name,
+            'problem_name_from_location': problem_name_from_location,
+            'num_graded': finished_instructor_graded,
+            'num_pending': submissions_pending,
+            'num_required': submissions_required,
+            'min_for_ml': control.minimum_to_use_ai,
             }
         location_info.append(location_dict)
 


### PR DESCRIPTION
Allow instructors to specify how many submissions should go to instructor scoring before peer or AI kick in.  @brianhw Please look when you have time.
