### PR TITLE
locking the celery version to 3.0.19

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -9,6 +9,7 @@ pytz==2012h
 MySQL-python==1.2.4
 boto==2.6.0
 lxml==3.0.1
+celery==3.0.19
 django-celery==3.0.11
 celery-with-redis==3.0
 django-nose==1.1


### PR DESCRIPTION
ora will bomb because celery 3.1 is not compatible with the current code
