### PR TITLE
Use uuid() to generate unique XQueue submission IDs during import

### DIFF
--- a/controller/management/commands/import_graded_essays.py
+++ b/controller/management/commands/import_graded_essays.py
@@ -13,9 +13,9 @@ import time
 import json
 import logging
 import sys
+from uuid import uuid4
 from ConfigParser import SafeConfigParser
 from datetime import datetime
-import test_util
 
 from controller.models import Submission, Grader
 from controller.models import GraderStatus, SubmissionState
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                 state=state,
                 student_response=text[i],
                 student_submission_time=timezone.now(),
-                xqueue_submission_id=test_util.generate_new_xqueue_id(),
+                xqueue_submission_id=uuid4().hex,
                 xqueue_submission_key="",
                 xqueue_queue_name="",
                 location=location,


### PR DESCRIPTION
This is a fix for the `import_graded_essays` Django management command.  Previously, this generated unique XQueue submission IDs using `test_util.generate_new_xqueue_id()`.  Unfortunately, that method randomized the length of the ID between 1 and 10, so we got lots of IDs of the form "aR".  Running the command multiple times would result in ID collisions, causing database errors.

@adampalay 
