### PR TITLE
Fixed discrepancy between the subscores and the total score and added some tests

### DIFF
--- a/peer_grading/tests.py
+++ b/peer_grading/tests.py
@@ -126,6 +126,75 @@ class LMSInterfacePeerGradingTest(unittest.TestCase):
 
         self.assertEqual(body['success'], True)
 
+    def test_save_grade_with_no_rubrics_and_submission_flagged(self):
+        """
+        Test save grade when submission is flagged and rubric score are not provided.
+        """
+
+        test_sub = test_util.get_sub("PE", "blah", LOCATION, "PE")
+        test_sub.save()
+
+        test_dict = {
+            'location': LOCATION,
+            'grader_id': STUDENT_ID,
+            'submission_id': 1,
+            'score': 5,
+            'feedback': 'feedback',
+            'submission_key': 'string',
+            'submission_flagged': True,
+            'rubric_scores_complete': False,
+            'rubric_scores': [],
+            }
+
+        content = self.c.post(
+            SAVE_GRADE,
+            test_dict,
+        )
+
+        body = json.loads(content.content)
+        #Should succeed, as we created a submission above that save_grade can use
+        self.assertEqual(body["success"], True)
+
+        sub = Submission.objects.get(id=1)
+
+        #Score should be 0.
+        self.assertEqual(sub.get_last_grader().score, 0)
+
+    def test_save_grade_with_no_rubrics_and_submission_unknown(self):
+        """
+        Test save grade when submission is mark as unknown and rubric score are not provided.
+        """
+
+        test_sub = test_util.get_sub("PE", "blah", LOCATION, "PE")
+        test_sub.save()
+
+        test_dict = {
+            'location': LOCATION,
+            'grader_id': STUDENT_ID,
+            'submission_id': 1,
+            'score': 5,
+            'feedback': 'feedback',
+            'submission_key': 'string',
+            'submission_flagged': False,
+            'answer_unknown': True,
+            'rubric_scores_complete': False,
+            'rubric_scores': [],
+            }
+
+        content = self.c.post(
+            SAVE_GRADE,
+            test_dict,
+        )
+
+        body = json.loads(content.content)
+        #Should succeed, as we created a submission above that save_grade can use
+        self.assertEqual(body["success"], True)
+
+        sub = Submission.objects.get(id=1)
+
+        #Score should be 0.
+        self.assertEqual(sub.get_last_grader().score, 0)
+
     def test_save_grade_false(self):
         test_dict={
             'location': LOCATION,

--- a/peer_grading/views.py
+++ b/peer_grading/views.py
@@ -161,6 +161,7 @@ def save_grade(request):
         success, targets=rubric_functions.generate_targets_from_rubric(sub.rubric)
         rubric_scores = [0 for l in targets]
         rubric_scores_complete = True
+        score = 0
 
     success, error_message = grader_util.validate_rubric_scores(rubric_scores, rubric_scores_complete, sub)
     if not success:


### PR DESCRIPTION
ORA-199

When a peer grade is submitted to ORA it records the 'score' and if the submission is marked as flagged and the peer grader did not provide any rubric scores, the rubric_scores are set to 0. This bug should only happen if the peer grade did not have any rubric_scores and its 'score' value was not 0.

Fixing this by score=0 when a submission is flagged or marked as unknown by peer grader and rubrics are not provided.
