### PR TITLE
Really large posts to ORA like feedback cause database issues.

### DIFF
--- a/peer_grading/tests.py
+++ b/peer_grading/tests.py
@@ -284,6 +284,37 @@ class LMSInterfacePeerGradingTest(unittest.TestCase):
         self.assertIsInstance(body['count_required'], int)
         self.assertIsInstance(body['count_available'], int)
 
+    def test_save_grade_with_large_feedback(self):
+        test_sub = test_util.get_sub("PE", "blah", LOCATION, "PE")
+        test_sub.save()
+
+        feedback = ""
+        for i in range(0, 3800):
+            feedback += "This is very long feedback."
+
+        test_dict = {
+            'location': LOCATION,
+            'grader_id': STUDENT_ID,
+            'submission_id': 1,
+            'score': 0,
+            'feedback': feedback,
+            'submission_key': 'string',
+            'submission_flagged': False,
+            'rubric_scores_complete': True,
+            'rubric_scores': [1, 1]
+        }
+
+        response = self.c.post(
+            SAVE_GRADE,
+            test_dict,
+        )
+
+        body = json.loads(response.content)
+
+        # Should not succeed.
+        self.assertEqual(body['success'], False)
+        self.assertEqual(body['error'], "Feedback is too long.")
+
 
 class LMSInterfaceCalibrationEssayTest(unittest.TestCase):
     def setUp(self):

--- a/peer_grading/views.py
+++ b/peer_grading/views.py
@@ -22,6 +22,7 @@ from django.db import connection
 log = logging.getLogger(__name__)
 
 _INTERFACE_VERSION = 1
+MAX_FEEDBACK_LENGTH = 102400
 
 @csrf_exempt
 @statsd.timed('open_ended_assessment.grading_controller.peer_grading.views.time',
@@ -119,6 +120,10 @@ def save_grade(request):
 
     #This is done to ensure that response is properly formatted on the lms side.
     feedback_dict = post_data['feedback']
+    feed_back_length = len(feedback_dict)
+
+    if feed_back_length > MAX_FEEDBACK_LENGTH:
+        return util._error_response("Feedback is too long.", _INTERFACE_VERSION)
 
     rubric_scores_complete = request.POST.get('rubric_scores_complete', False)
     rubric_scores = request.POST.getlist('rubric_scores', [])

--- a/staff_grading/tests.py
+++ b/staff_grading/tests.py
@@ -262,5 +262,32 @@ class StaffGradingViewTest(unittest.TestCase):
 
         self.assertEqual(sl.problem_name(), problem_id_two)
 
+    def test_save_grade_with_large_feedback(self):
+        test_sub = test_util.get_sub("IN", STUDENT_ID, LOCATION)
+        test_sub.save()
 
+        feedback = ""
+        for i in range(0, 3800):
+            feedback += "This is very long feedback."
 
+        post_data = {
+            'course_id': COURSE_ID,
+            'grader_id': STUDENT_ID,
+            'submission_id': 1,
+            'score': 0,
+            'feedback': feedback,
+            'skipped': False,
+            'rubric_scores_complete': True,
+            'rubric_scores': [1, 1]
+        }
+
+        response = self.c.post(
+            SAVE_GRADE,
+            post_data,
+        )
+
+        body = json.loads(response.content)
+
+        # Should not succeed.
+        self.assertEqual(body['success'], False)
+        self.assertEqual(body['error'], "Feedback is too long.")

--- a/staff_grading/views.py
+++ b/staff_grading/views.py
@@ -30,6 +30,7 @@ from django.db import connection
 log = logging.getLogger(__name__)
 
 _INTERFACE_VERSION = 1
+MAX_FEEDBACK_LENGTH = 102400
 
 
 @csrf_exempt
@@ -174,6 +175,10 @@ def save_grade(request):
         # These have to be non-None
         score is None or feedback is None):
         return util._error_response("required_parameter_missing", _INTERFACE_VERSION)
+
+    feed_back_length = len(feedback)
+    if feed_back_length > MAX_FEEDBACK_LENGTH:
+        return util._error_response("Feedback is too long.", _INTERFACE_VERSION)
 
     if skipped:
         success, sub = staff_grading_util.set_instructor_grading_item_back_to_preferred_grader(submission_id)


### PR DESCRIPTION
ORA-201

When scores and comments are posted back to LMS, really large comments (>100K characters) can cause database issues.
