### PR TITLE
Fixed img tags are allowed without filtering of their attributes.

### DIFF
--- a/controller/tests.py
+++ b/controller/tests.py
@@ -395,6 +395,15 @@ class ControllerUtilTests(unittest.TestCase):
         self.assertEqual(body['success'], True)
         self.assertEqual(body['eta'], settings.DEFAULT_ESTIMATED_GRADING_TIME)
 
+    def test_sanitize_html(self):
+        feedback = "This is a sample feedback. <img src='abc' onerror=alert(1)>"
+
+        sanitized_feedback = util.sanitize_html(feedback)
+
+        # Sanitized feedback should not contain onerror attribute.
+        self.assertFalse("onerror" in sanitized_feedback)
+
+
 class ExpireSubmissionsTests(unittest.TestCase):
     fixtures = ['/controller/test_data.json']
     def setUp(self):

--- a/controller/util.py
+++ b/controller/util.py
@@ -396,7 +396,15 @@ def log_connection_data():
 
 def sanitize_html(text):
     try:
-        cleaner = Cleaner(style=True, links=True, add_nofollow=False, page_structure=True, safe_attrs_only=False, allow_tags = ["img", "a"])
+        cleaner = Cleaner(
+            style=True,
+            links=True,
+            add_nofollow=False,
+            page_structure=True,
+            safe_attrs_only=False,
+            remove_unknown_tags=False,
+            allow_tags=["img", "a"]
+        )
         clean_html = cleaner.clean_html(text)
         clean_html = re.sub(r'</p>$', '', re.sub(r'^<p>', '', clean_html))
     except Exception:


### PR DESCRIPTION
ORA-255

Image tags are allowed without filtering of their attributes in feedback, when a feedback is passed to sanitize_html() here https://github.com/edx/edx-ora/blob/master/controller/util.py#L397-L404 then it will raise an exception:
"ValueError: It does not make sense to pass in both allow_tags and remove_unknown_tags"
because of remove_unknown_tags=True by default and in exception handling it will pass all text and html without filtering.
