### PR TITLE
Increment MySQL python library to fix Travis build

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -6,7 +6,7 @@ South==0.7.6
 reportlab==2.6
 requests==1.1.0
 pytz==2012h
-MySQL-python==1.2.4
+MySQL-python==1.2.5
 boto==2.6.0
 lxml==3.0.1
 celery==3.0.19


### PR DESCRIPTION
Recent builds in Travis have been failing when trying to install MySQL-python.  I suspect that this is a combination of:

1) https://github.com/farcepest/MySQLdb1/pull/18
2) Travis not pinning the version of setuptools installed.

This fix is not ideal, since it changes the requirements.  One option would be to merge this into master, but not release it back into production.

@adampalay @feanil What do you think?
