### PR TITLE
matplotlib 1.2.1 can no longer be downloaded from PyPI.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy==0.11.0
 coverage==3.5.3   # coverage breaks travis, so move it out of base-requirements
 sphinx==1.1.3
 django-sphinx-autodoc==0.2
-matplotlib==1.2.0
+matplotlib==1.3.1
 gunicorn
 wsgiref
 ipython


### PR DESCRIPTION
It is available from source forge but not as a trusted package.  We would either have to upgrade or
download the unverified package.  Looking at the changelog there is only one minor backwards
incompatible change and changes the icon of the diamond in diagrams.
